### PR TITLE
#2 - Cria container postgres em sua última versão usando `docker-compose`.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+postgres_data/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-postgres_data/
+.postgres-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
     expose:
       - "5432"
     volumes:
-      - ./postgres_data:/var/lib/postgresql/data
-      - ./docker/entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./.postgres-data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: fitflow
-      POSTGRES_PASSWORD: fitflow
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: fitflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.4"
+services:
+  postgres:
+    image: postgres:latest
+    container_name: fitflow-postgres
+    ports:
+      - "5432:5432"
+    expose:
+      - "5432"
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+      - ./docker/entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    environment:
+      POSTGRES_USER: fitflow
+      POSTGRES_PASSWORD: fitflow
+      POSTGRES_DB: fitflow

--- a/docker/entrypoint-initdb.d/initialize-databse.sh
+++ b/docker/entrypoint-initdb.d/initialize-databse.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-    CREATE DATABASE fitflow_test;
-    GRANT ALL PRIVILEGES ON DATABASE fitflow_test TO fitflow;
-EOSQL

--- a/docker/entrypoint-initdb.d/initialize-databse.sh
+++ b/docker/entrypoint-initdb.d/initialize-databse.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE DATABASE fitflow_test;
+    GRANT ALL PRIVILEGES ON DATABASE fitflow_test TO fitflow;
+EOSQL


### PR DESCRIPTION
## Descrição 📖

Cria container postgres em sua última versão usando `docker-compose`.

Como utilizar:

docker-compose up ou docker-compose up -d para iniciar o banco
docker-compose logs -f para ver os logs (quando iniciado com -d)

## Tarefas Realizadas 📝

- Criação do container postgres com `docker-compose`.
- Utiliza a ultima versão do postgres.

## Mudanças Relacionadas ⚙️

Issue [#2 - Setup inicial do projeto](https://github.com/fullstackclub-labs/fit-flow/issues/2) 
PR [#20 - #2 - Setup inicial do projeto ](https://github.com/fullstackclub-labs/fit-flow/pull/20)

## Testes Realizados 🔍

- Conexão com banco de dados postgres através do container.

## Checklist ✅
 
## Notas Adicionais 📄

_OBS: Foi utilizado a ultima versão o postgres, mas gostaria de sugerir o uso do postgres 13  com o alpine para melhor performance_  
